### PR TITLE
Fix/stat extend with graph

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.2.0-alpha05'
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'com.github.PhilJay:MPAndroidChart:v3.1.0'
 
     debugImplementation 'com.github.ChuckerTeam.Chucker:library:3.2.0'
     releaseImplementation 'com.github.ChuckerTeam.Chucker:library-no-op:3.2.0'

--- a/app/src/main/java/ethiopia/covid/android/data/JohnsHopkinsItem.java
+++ b/app/src/main/java/ethiopia/covid/android/data/JohnsHopkinsItem.java
@@ -1,0 +1,119 @@
+package ethiopia.covid.android.data;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by BrookMG on 4/7/2020 in ethiopia.covid.android.data
+ * inside the project CoVidEt .
+ */
+public class JohnsHopkinsItem {
+
+    /*
+        {
+          "country": "Ethiopia",
+          "provinces": [
+            "mainland"
+          ],
+          "timeline": {
+            "cases": {
+              "3/8/20": 0,
+              "3/9/20": 0,
+              "3/10/20": 0,
+              "3/11/20": 0,
+              "3/12/20": 0,
+              "3/13/20": 1,
+              ...
+            },
+            "deaths": {
+              "3/8/20": 0,
+              "3/9/20": 0,
+              "3/10/20": 0,
+              "3/11/20": 0,
+              "3/12/20": 0,
+              "3/13/20": 0,
+              ...
+            },
+            "recovered": {
+              "3/8/20": 0,
+              "3/9/20": 0,
+              "3/10/20": 0,
+              "3/11/20": 0,
+              "3/12/20": 0,
+              "3/13/20": 0,
+              ...
+            }
+          }
+        }
+     */
+
+    public static class TimeLine {
+        private Map<String, Integer> cases;
+        private Map<String, Integer> deaths;
+        private Map<String, Integer> recovered;
+
+        public TimeLine(Map<String, Integer> cases, Map<String, Integer> deaths, Map<String, Integer> recovered) {
+            this.cases = cases;
+            this.deaths = deaths;
+            this.recovered = recovered;
+        }
+
+        public Map<String, Integer> getCases() {
+            return cases;
+        }
+
+        public void setCases(Map<String, Integer> cases) {
+            this.cases = cases;
+        }
+
+        public Map<String, Integer> getDeaths() {
+            return deaths;
+        }
+
+        public void setDeaths(Map<String, Integer> deaths) {
+            this.deaths = deaths;
+        }
+
+        public Map<String, Integer> getRecovered() {
+            return recovered;
+        }
+
+        public void setRecovered(Map<String, Integer> recovered) {
+            this.recovered = recovered;
+        }
+    }
+
+    private String country;
+    private List<String> provinces;
+    private TimeLine timeline;
+
+    public JohnsHopkinsItem(String country, List<String> provinces, TimeLine timeline) {
+        this.country = country;
+        this.provinces = provinces;
+        this.timeline = timeline;
+    }
+
+    public String getCountry() {
+        return country;
+    }
+
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    public List<String> getProvinces() {
+        return provinces;
+    }
+
+    public void setProvinces(List<String> provinces) {
+        this.provinces = provinces;
+    }
+
+    public TimeLine getTimeline() {
+        return timeline;
+    }
+
+    public void setTimeline(TimeLine timeline) {
+        this.timeline = timeline;
+    }
+}

--- a/app/src/main/java/ethiopia/covid/android/data/LineChartItem.java
+++ b/app/src/main/java/ethiopia/covid/android/data/LineChartItem.java
@@ -1,0 +1,54 @@
+package ethiopia.covid.android.data;
+
+import java.util.List;
+
+/**
+ * Created by BrookMG on 4/7/2020 in ethiopia.covid.android.data
+ * inside the project CoVidEt .
+ */
+public class LineChartItem {
+
+    private List<Integer> values;
+    private String chartLabel;
+    private Integer lineColor;
+    private Integer circleColor;
+
+    public LineChartItem(List<Integer> values, String chartLabel, Integer lineColor, Integer circleColor) {
+        this.values = values;
+        this.chartLabel = chartLabel;
+        this.lineColor = lineColor;
+        this.circleColor = circleColor;
+    }
+
+    public List<Integer> getValues() {
+        return values;
+    }
+
+    public void setValues(List<Integer> values) {
+        this.values = values;
+    }
+
+    public String getChartLabel() {
+        return chartLabel;
+    }
+
+    public void setChartLabel(String chartLabel) {
+        this.chartLabel = chartLabel;
+    }
+
+    public Integer getLineColor() {
+        return lineColor;
+    }
+
+    public void setLineColor(Integer lineColor) {
+        this.lineColor = lineColor;
+    }
+
+    public Integer getCircleColor() {
+        return circleColor;
+    }
+
+    public void setCircleColor(Integer circleColor) {
+        this.circleColor = circleColor;
+    }
+}

--- a/app/src/main/java/ethiopia/covid/android/data/Region.java
+++ b/app/src/main/java/ethiopia/covid/android/data/Region.java
@@ -1,0 +1,52 @@
+package ethiopia.covid.android.data;
+
+/**
+ * Created by BrookMG on 4/6/2020 in ethiopia.covid.android.data
+ * inside the project CoVidEt .
+ */
+public class Region {
+
+    private String regionName;
+    private String regionCode;
+    private int numberOfInfected;
+    private int numberOfDeaths;
+
+    public Region(String regionName, String regionCode, int numberOfInfected, int numberOfDeaths) {
+        this.regionName = regionName;
+        this.regionCode = regionCode;
+        this.numberOfInfected = numberOfInfected;
+        this.numberOfDeaths = numberOfDeaths;
+    }
+
+    public String getRegionName() {
+        return regionName;
+    }
+
+    public void setRegionName(String regionName) {
+        this.regionName = regionName;
+    }
+
+    public String getRegionCode() {
+        return regionCode;
+    }
+
+    public void setRegionCode(String regionCode) {
+        this.regionCode = regionCode;
+    }
+
+    public int getNumberOfInfected() {
+        return numberOfInfected;
+    }
+
+    public void setNumberOfInfected(int numberOfInfected) {
+        this.numberOfInfected = numberOfInfected;
+    }
+
+    public int getNumberOfDeaths() {
+        return numberOfDeaths;
+    }
+
+    public void setNumberOfDeaths(int numberOfDeaths) {
+        this.numberOfDeaths = numberOfDeaths;
+    }
+}

--- a/app/src/main/java/ethiopia/covid/android/data/StatRecyclerItem.java
+++ b/app/src/main/java/ethiopia/covid/android/data/StatRecyclerItem.java
@@ -8,18 +8,21 @@ import java.util.List;
  */
 public class StatRecyclerItem {
 
-    private int type = 0;  // 0 -> Table , 1 -> Pie , 2 -> Status card
+    private int type = 0;  // 0 -> Table , 1 -> Pie , 2 -> Status card, 3 -> Patients , 4 -> Line
 
     // Table stuff
     private List<CovidStatItem> tableItems;
     private List<String> headers;
     private int fixedHeaderCount = 0;
 
-    // todo: Pie stuff
     private String pieCardTitle;
     private List<Integer> pieValues;
     private List<String> pieLabels;
     private List<Integer> pieColors;
+
+    private String lineCardTitle;
+    private List<Integer> lineValues;
+    private List<String> lineLabels;
 
     // Status Card
     private String country;
@@ -30,6 +33,13 @@ public class StatRecyclerItem {
 
     // Patient table stuff
     private List<PatientItem> patientItems;
+
+    public StatRecyclerItem(String lineCardTitle, List<Integer> lineValues, List<String> lineLabels) {
+        this.type = 4;
+        this.lineCardTitle = lineCardTitle;
+        this.lineValues = lineValues;
+        this.lineLabels = lineLabels;
+    }
 
     public StatRecyclerItem(String pieCardTitle, List<Integer> pieValues, List<String> pieLabels, List<Integer> pieColors) {
         this.type = 1;
@@ -181,4 +191,29 @@ public class StatRecyclerItem {
     public void setPieCardTitle(String pieCardTitle) {
         this.pieCardTitle = pieCardTitle;
     }
+
+    public String getLineCardTitle() {
+        return lineCardTitle;
+    }
+
+    public void setLineCardTitle(String lineCardTitle) {
+        this.lineCardTitle = lineCardTitle;
+    }
+
+    public List<Integer> getLineValues() {
+        return lineValues;
+    }
+
+    public void setLineValues(List<Integer> lineValues) {
+        this.lineValues = lineValues;
+    }
+
+    public List<String> getLineLabels() {
+        return lineLabels;
+    }
+
+    public void setLineLabels(List<String> lineLabels) {
+        this.lineLabels = lineLabels;
+    }
+
 }

--- a/app/src/main/java/ethiopia/covid/android/data/StatRecyclerItem.java
+++ b/app/src/main/java/ethiopia/covid/android/data/StatRecyclerItem.java
@@ -16,7 +16,10 @@ public class StatRecyclerItem {
     private int fixedHeaderCount = 0;
 
     // todo: Pie stuff
-
+    private String pieCardTitle;
+    private List<Integer> pieValues;
+    private List<String> pieLabels;
+    private List<Integer> pieColors;
 
     // Status Card
     private String country;
@@ -27,6 +30,14 @@ public class StatRecyclerItem {
 
     // Patient table stuff
     private List<PatientItem> patientItems;
+
+    public StatRecyclerItem(String pieCardTitle, List<Integer> pieValues, List<String> pieLabels, List<Integer> pieColors) {
+        this.type = 1;
+        this.pieCardTitle = pieCardTitle;
+        this.pieValues = pieValues;
+        this.pieLabels = pieLabels;
+        this.pieColors = pieColors;
+    }
 
     public StatRecyclerItem(String country, int totalInfected, int totalDeath, int totalRecovered, int totalTested) {
         this.type = 2;
@@ -137,5 +148,37 @@ public class StatRecyclerItem {
 
     public void setTotalTested(int totalTested) {
         this.totalTested = totalTested;
+    }
+
+    public List<Integer> getPieValues() {
+        return pieValues;
+    }
+
+    public void setPieValues(List<Integer> pieValues) {
+        this.pieValues = pieValues;
+    }
+
+    public List<String> getPieLabels() {
+        return pieLabels;
+    }
+
+    public void setPieLabels(List<String> pieLabels) {
+        this.pieLabels = pieLabels;
+    }
+
+    public List<Integer> getPieColors() {
+        return pieColors;
+    }
+
+    public void setPieColors(List<Integer> pieColors) {
+        this.pieColors = pieColors;
+    }
+
+    public String getPieCardTitle() {
+        return pieCardTitle;
+    }
+
+    public void setPieCardTitle(String pieCardTitle) {
+        this.pieCardTitle = pieCardTitle;
     }
 }

--- a/app/src/main/java/ethiopia/covid/android/data/StatRecyclerItem.java
+++ b/app/src/main/java/ethiopia/covid/android/data/StatRecyclerItem.java
@@ -21,7 +21,7 @@ public class StatRecyclerItem {
     private List<Integer> pieColors;
 
     private String lineCardTitle;
-    private List<Integer> lineValues;
+    private List<LineChartItem> lineChartItems;
     private List<String> lineLabels;
 
     // Status Card
@@ -34,10 +34,10 @@ public class StatRecyclerItem {
     // Patient table stuff
     private List<PatientItem> patientItems;
 
-    public StatRecyclerItem(String lineCardTitle, List<Integer> lineValues, List<String> lineLabels) {
+    public StatRecyclerItem(String lineCardTitle, List<LineChartItem> lineChartItems, List<String> lineLabels) {
         this.type = 4;
         this.lineCardTitle = lineCardTitle;
-        this.lineValues = lineValues;
+        this.lineChartItems = lineChartItems;
         this.lineLabels = lineLabels;
     }
 
@@ -200,12 +200,12 @@ public class StatRecyclerItem {
         this.lineCardTitle = lineCardTitle;
     }
 
-    public List<Integer> getLineValues() {
-        return lineValues;
+    public List<LineChartItem> getLineChartItems() {
+        return lineChartItems;
     }
 
-    public void setLineValues(List<Integer> lineValues) {
-        this.lineValues = lineValues;
+    public void setLineChartItems(List<LineChartItem> lineChartItems) {
+        this.lineChartItems = lineChartItems;
     }
 
     public List<String> getLineLabels() {
@@ -215,5 +215,4 @@ public class StatRecyclerItem {
     public void setLineLabels(List<String> lineLabels) {
         this.lineLabels = lineLabels;
     }
-
 }

--- a/app/src/main/java/ethiopia/covid/android/network/API.java
+++ b/app/src/main/java/ethiopia/covid/android/network/API.java
@@ -5,6 +5,7 @@ import android.os.Looper;
 import android.util.Log;
 
 import androidx.annotation.UiThread;
+import androidx.core.content.ContextCompat;
 
 import com.chuckerteam.chucker.api.ChuckerInterceptor;
 
@@ -25,6 +26,8 @@ import ethiopia.covid.android.BuildConfig;
 import ethiopia.covid.android.R;
 import ethiopia.covid.android.data.Case;
 import ethiopia.covid.android.data.CovidStatItem;
+import ethiopia.covid.android.data.JohnsHopkinsItem;
+import ethiopia.covid.android.data.LineChartItem;
 import ethiopia.covid.android.data.PatientItem;
 import ethiopia.covid.android.data.Patients;
 import ethiopia.covid.android.data.Region;
@@ -197,7 +200,61 @@ public class API {
                                 patients.getResults()
                         )
                 );
-            } catch (Exception ignored) {}
+            } catch (Exception ignored) {
+
+            }
+
+            try {
+                Response<JohnsHopkinsItem> response = getWorldCovidAPI().getCountryHistoricalData("et").execute();
+                JohnsHopkinsItem johnsHopkinsItem = response.body();
+                List<Integer> caseNumbers = new ArrayList<>();
+                List<Integer> deathNumbers = new ArrayList<>();
+                List<Integer> recoveryNumbers = new ArrayList<>();
+                List<String> caseDate = new ArrayList<>();
+
+                for (Entry<String, Integer> item : johnsHopkinsItem.getTimeline().getCases().entrySet()) {
+                    caseDate.add(item.getKey());
+                    caseNumbers.add(item.getValue());
+                }
+
+                for (Entry<String, Integer> item : johnsHopkinsItem.getTimeline().getDeaths().entrySet()) {
+                    deathNumbers.add(item.getValue());
+                }
+
+                for (Entry<String, Integer> item : johnsHopkinsItem.getTimeline().getRecovered().entrySet()) {
+                    recoveryNumbers.add(item.getValue());
+                }
+
+                returnable.add(
+                        new StatRecyclerItem(
+                                "Ethiopia Covid Distribution",
+                                Arrays.asList(
+                                        new LineChartItem(
+                                                caseNumbers,
+                                                "Cases",
+                                                ContextCompat.getColor(App.getInstance() , R.color.purple_0),
+                                                ContextCompat.getColor(App.getInstance() , R.color.purple_1)
+                                        ),
+                                        new LineChartItem(
+                                                deathNumbers,
+                                                "Deaths",
+                                                ContextCompat.getColor(App.getInstance() , R.color.red_0),
+                                                ContextCompat.getColor(App.getInstance() , R.color.red_1)
+                                        ),
+                                        new LineChartItem(
+                                                recoveryNumbers,
+                                                "Recovery",
+                                                ContextCompat.getColor(App.getInstance() , R.color.green_0),
+                                                ContextCompat.getColor(App.getInstance() , R.color.green_1)
+                                        )
+                                ),
+                                caseDate
+                        )
+                );
+
+            } catch (Exception ignored) {
+                Log.e("Graph" , ignored.getMessage());
+            }
 
             try {
                 Response<List<WorldCovid>> worldStatResponse = getWorldCovidAPI().getListOfStat().execute();

--- a/app/src/main/java/ethiopia/covid/android/network/API.java
+++ b/app/src/main/java/ethiopia/covid/android/network/API.java
@@ -162,7 +162,7 @@ public class API {
                     worldStatItems.add(
                             new CovidStatItem(
                                     location.getCountry().replace(" ", ""),
-                                    location.getTodayCases(),
+                                    location.getCases(),
                                     location.getActive(),
                                     location.getDeaths(),
                                     location.getRecovered(),

--- a/app/src/main/java/ethiopia/covid/android/network/PMOCovidAPI.java
+++ b/app/src/main/java/ethiopia/covid/android/network/PMOCovidAPI.java
@@ -14,6 +14,6 @@ inside the project CoVidEt .
 public interface PMOCovidAPI {
 
     @GET("cases") public Call<List<Case>> getCases();
-    @GET("patients") public Call<Patients> getPatients();
+    @GET("patients?limit=100&page=0") public Call<Patients> getPatients();
 
 }

--- a/app/src/main/java/ethiopia/covid/android/network/WorldCovidAPI.java
+++ b/app/src/main/java/ethiopia/covid/android/network/WorldCovidAPI.java
@@ -2,9 +2,11 @@ package ethiopia.covid.android.network;
 
 import java.util.List;
 
+import ethiopia.covid.android.data.JohnsHopkinsItem;
 import ethiopia.covid.android.data.WorldCovid;
 import retrofit2.Call;
 import retrofit2.http.GET;
+import retrofit2.http.Path;
 import retrofit2.http.Query;
 
 /**
@@ -14,5 +16,6 @@ inside the project CoVidEt .
 public interface WorldCovidAPI {
 
     @GET("countries") public Call<List<WorldCovid>> getListOfStat();
+    @GET("v2/historical/{country}?limit=30") public Call<JohnsHopkinsItem> getCountryHistoricalData(@Path("country") String country);
 
 }

--- a/app/src/main/java/ethiopia/covid/android/ui/adapter/StatRecyclerAdapter.java
+++ b/app/src/main/java/ethiopia/covid/android/ui/adapter/StatRecyclerAdapter.java
@@ -1,7 +1,6 @@
 package ethiopia.covid.android.ui.adapter;
 
 import android.graphics.Color;
-import android.graphics.DashPathEffect;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -15,21 +14,16 @@ import com.github.mikephil.charting.animation.Easing;
 import com.github.mikephil.charting.charts.LineChart;
 import com.github.mikephil.charting.charts.PieChart;
 import com.github.mikephil.charting.components.Legend;
-import com.github.mikephil.charting.components.LimitLine;
 import com.github.mikephil.charting.components.XAxis;
-import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.LineData;
 import com.github.mikephil.charting.data.LineDataSet;
 import com.github.mikephil.charting.data.PieData;
 import com.github.mikephil.charting.data.PieDataSet;
 import com.github.mikephil.charting.data.PieEntry;
-import com.github.mikephil.charting.formatter.IFillFormatter;
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter;
 import com.github.mikephil.charting.formatter.PercentFormatter;
-import com.github.mikephil.charting.interfaces.dataprovider.LineDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
-import com.github.mikephil.charting.renderer.XAxisRenderer;
 import com.github.mikephil.charting.utils.MPPointF;
 import com.google.android.material.card.MaterialCardView;
 
@@ -40,6 +34,7 @@ import java.util.Locale;
 
 import ethiopia.covid.android.R;
 import ethiopia.covid.android.data.CovidStatItem;
+import ethiopia.covid.android.data.LineChartItem;
 import ethiopia.covid.android.data.PatientItem;
 import ethiopia.covid.android.data.StatRecyclerItem;
 import ethiopia.covid.android.ui.widget.Table;
@@ -294,64 +289,67 @@ public class StatRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             l.setForm(Legend.LegendForm.LINE);
             l.setTextColor(Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ? Color.BLACK : Color.WHITE);
 
-            ArrayList<Entry> values = new ArrayList<>();
+            ArrayList<ILineDataSet> dataSets = new ArrayList<>();
 
-            int i = 0;
-            for (Integer item : statRecyclerItemList.get(position).getLineValues()) {
-                values.add(new Entry(i, item));
-                i++;
+            for (LineChartItem lineChartItem : statRecyclerItemList.get(position).getLineChartItems()) {
+                LineDataSet dataSet;
+
+                ArrayList<Entry> values = new ArrayList<>();
+
+                int i = 0;
+                for (Integer item : lineChartItem.getValues()) {
+                    values.add(new Entry(i, item));
+                    i++;
+                }
+
+                if (chart.getData() != null && chart.getData().getDataSetCount() > 0) {
+                    dataSet = (LineDataSet) chart.getData().getDataSetByIndex(0);
+                    dataSet.setValues(values);
+                    dataSet.notifyDataSetChanged();
+                    chart.getData().notifyDataChanged();
+                    chart.notifyDataSetChanged();
+                } else {
+
+                    // create a dataset, which should belong to a country
+                    dataSet = new LineDataSet(values, lineChartItem.getChartLabel());
+                    dataSet.setDrawIcons(false);
+
+                    dataSet.setColor(lineChartItem.getLineColor());
+                    dataSet.setValueTextColor(Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ? Color.BLACK : Color.WHITE);
+                    dataSet.setCircleColor(lineChartItem.getCircleColor());
+
+                    // line thickness and point size
+                    dataSet.setLineWidth(1f);
+                    dataSet.setCircleRadius(3f);
+
+                    // draw points as solid circles
+                    dataSet.setDrawCircleHole(false);
+
+                    // customize legend entry
+                    dataSet.setFormLineWidth(1f);
+                    dataSet.setFormSize(15.f);
+
+                    // text size of values
+                    dataSet.setValueTextSize(9f);
+
+                    // draw selection line as dashed
+                    dataSet.setHighLightColor(ContextCompat.getColor(holder.itemView.getContext() , R.color.purple_0));
+                    dataSet.enableDashedHighlightLine(10f, 5f, 0f);
+
+                    // set the filled area
+                    dataSet.setDrawFilled(false);
+
+                    dataSets.add(dataSet); // add the data sets
+                }
             }
 
-            LineDataSet set1;
+            // create a data object with the data sets
+            LineData data = new LineData(dataSets);
+            data.setDrawValues(false);
+            data.setValueTextColor(Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ? Color.BLACK : Color.WHITE);
 
-            if (chart.getData() != null && chart.getData().getDataSetCount() > 0) {
-                set1 = (LineDataSet) chart.getData().getDataSetByIndex(0);
-                set1.setValues(values);
-                set1.notifyDataSetChanged();
-                chart.getData().notifyDataChanged();
-                chart.notifyDataSetChanged();
-            } else {
-
-                // create a dataset, which should belong to a country
-                set1 = new LineDataSet(values, "Ethiopia");
-                set1.setDrawIcons(false);
-
-                set1.setColor(ContextCompat.getColor(holder.itemView.getContext() , R.color.purple_0));
-                set1.setValueTextColor(Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ? Color.BLACK : Color.WHITE);
-                set1.setCircleColor(ContextCompat.getColor(holder.itemView.getContext() , R.color.purple_1));
-
-                // line thickness and point size
-                set1.setLineWidth(1f);
-                set1.setCircleRadius(3f);
-
-                // draw points as solid circles
-                set1.setDrawCircleHole(false);
-
-                // customize legend entry
-                set1.setFormLineWidth(1f);
-                set1.setFormSize(15.f);
-
-                // text size of values
-                set1.setValueTextSize(9f);
-
-                // draw selection line as dashed
-                set1.setHighLightColor(ContextCompat.getColor(holder.itemView.getContext() , R.color.purple_0));
-                set1.enableDashedHighlightLine(10f, 5f, 0f);
-
-                // set the filled area
-                set1.setDrawFilled(false);
-
-                ArrayList<ILineDataSet> dataSets = new ArrayList<>();
-                dataSets.add(set1); // add the data sets
-
-                // create a data object with the data sets
-                LineData data = new LineData(dataSets);
-                data.setValueTextColor(Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ? Color.BLACK : Color.WHITE);
-
-                // set data
-                chart.setData(data);
-            }
-
+            // set data
+            chart.setData(data);
         }
         else {
 //            ViewGroup.LayoutParams params = ((HeaderViewHolder) holder).blankView.getLayoutParams();

--- a/app/src/main/java/ethiopia/covid/android/ui/adapter/StatRecyclerAdapter.java
+++ b/app/src/main/java/ethiopia/covid/android/ui/adapter/StatRecyclerAdapter.java
@@ -21,6 +21,9 @@ import ethiopia.covid.android.data.PatientItem;
 import ethiopia.covid.android.data.StatRecyclerItem;
 import ethiopia.covid.android.ui.widget.Table;
 import ethiopia.covid.android.util.Constant;
+import ethiopia.covid.android.util.Utils;
+
+import static ethiopia.covid.android.util.Utils.formatNumber;
 
 /**
  * Created by BrookMG on 3/24/2020 in ethiopia.covid.android.ui.adapter
@@ -71,11 +74,11 @@ public class StatRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             for (CovidStatItem item : statRecyclerItemList.get(position).getTableItems()) {
                 rowItems.add(Arrays.asList(
                         String.valueOf(item.getIdentifier()),
-                        String.valueOf(item.getInfected()),
-                        String.valueOf(item.getActive()),
-                        String.valueOf(item.getDeath()),
-                        String.valueOf(item.getRecovered()),
-                        String.valueOf(item.getCritical()),
+                        formatNumber(item.getInfected()),
+                        formatNumber(item.getActive()),
+                        formatNumber(item.getDeath()),
+                        formatNumber(item.getRecovered()),
+                        formatNumber(item.getCritical()),
                         String.valueOf(item.getCasePMillion()),
                         String.valueOf(item.getDeathsPMillion())
                 ));

--- a/app/src/main/java/ethiopia/covid/android/ui/adapter/StatRecyclerAdapter.java
+++ b/app/src/main/java/ethiopia/covid/android/ui/adapter/StatRecyclerAdapter.java
@@ -1,13 +1,23 @@
 package ethiopia.covid.android.ui.adapter;
 
+import android.graphics.Color;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.AppCompatTextView;
+import androidx.core.content.ContextCompat;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.github.mikephil.charting.animation.Easing;
+import com.github.mikephil.charting.charts.PieChart;
+import com.github.mikephil.charting.components.Legend;
+import com.github.mikephil.charting.data.PieData;
+import com.github.mikephil.charting.data.PieDataSet;
+import com.github.mikephil.charting.data.PieEntry;
+import com.github.mikephil.charting.formatter.PercentFormatter;
+import com.github.mikephil.charting.utils.MPPointF;
 import com.google.android.material.card.MaterialCardView;
 
 import java.util.ArrayList;
@@ -56,6 +66,10 @@ public class StatRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             case STATUS_CARD:
                 return new StatusCardViewHolder(
                         LayoutInflater.from(parent.getContext()).inflate(R.layout.status_card_recycler_element, parent, false)
+                );
+            case PIE_CHART:
+                return new CovidStatisticPieViewHolder(
+                        LayoutInflater.from(parent.getContext()).inflate(R.layout.stat_table_pie_element, parent, false)
                 );
         }
 
@@ -133,6 +147,85 @@ public class StatRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
                     statRecyclerItemList.get(position).getFixedHeaderCount(), 8
             );
 
+        } else if (getItemViewType(position) == PIE_CHART) {
+            position -= 1;
+
+            ((CovidStatisticPieViewHolder) holder).mainCardView.setContentPadding(0,0,0,0);
+            ((CovidStatisticPieViewHolder) holder).pieCardTitle.setText(statRecyclerItemList.get(position).getPieCardTitle());
+            ArrayList<PieEntry> entries = new ArrayList<>();
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setUsePercentValues(true);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.getDescription().setEnabled(false);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setExtraOffsets(5, 10, 5, 5);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setDragDecelerationFrictionCoef(0.95f);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setDrawHoleEnabled(true);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setHoleColor(
+                    Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ? Color.WHITE :
+                            ContextCompat.getColor(holder.itemView.getContext() , R.color.black_2)
+            );
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setTransparentCircleAlpha(110);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setHoleRadius(40f);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setTransparentCircleRadius(44f);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setDrawCenterText(true);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setRotationAngle(0);
+            // enable rotation of the chart by touch
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setRotationEnabled(true);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setHighlightPerTapEnabled(true);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.animateY(400, Easing.EaseInOutQuad);
+
+            Legend l = ((CovidStatisticPieViewHolder) holder).mainPieChart.getLegend();
+            l.setVerticalAlignment(Legend.LegendVerticalAlignment.TOP);
+            l.setHorizontalAlignment(Legend.LegendHorizontalAlignment.RIGHT);
+            l.setOrientation(Legend.LegendOrientation.VERTICAL);
+            l.setTextColor(Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ? Color.BLACK : Color.WHITE);
+            l.setDrawInside(false);
+            l.setXEntrySpace(7f);
+            l.setYEntrySpace(0f);
+            l.setYOffset(0f);
+
+            // entry label styling
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setEntryLabelColor(Color.WHITE);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setDrawEntryLabels(false);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setNoDataTextColor(
+                    Utils.getCurrentTheme(holder.itemView.getContext()) == 0 ?
+                            Color.BLACK : Color.WHITE
+            );
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setEntryLabelTextSize(12f);
+
+            for (int i = 0; i < statRecyclerItemList.get(position).getPieValues().size(); i++) {
+                entries.add(new PieEntry(
+                        statRecyclerItemList.get(position).getPieValues().get(i),
+                        statRecyclerItemList.get(position).getPieLabels().get(i)
+                ));
+            }
+
+            PieDataSet mainDataSet = new PieDataSet(entries, "");
+            mainDataSet.setDrawIcons(false);
+            mainDataSet.setSliceSpace(1f);
+            mainDataSet.setIconsOffset(new MPPointF(0, 40));
+            mainDataSet.setSelectionShift(5f);
+
+            mainDataSet.setColors(statRecyclerItemList.get(position).getPieColors());
+
+            PieData data = new PieData(mainDataSet);
+            data.setValueFormatter(new PercentFormatter(
+                    ((CovidStatisticPieViewHolder) holder).mainPieChart
+            ));
+
+            data.setValueTextSize(11f);
+            data.setValueTextColor(Color.WHITE);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.setData(data);
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.highlightValues(null);
+
+            ((CovidStatisticPieViewHolder) holder).mainPieChart.invalidate();
         } else {
 //            ViewGroup.LayoutParams params = ((HeaderViewHolder) holder).blankView.getLayoutParams();
 //            params.height = dpToPx(holder.itemView.getContext(), 116);
@@ -157,6 +250,19 @@ public class StatRecyclerAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
     @Override
     public int getItemCount() {
         return statRecyclerItemList.size()+1;
+    }
+
+    private static class CovidStatisticPieViewHolder extends RecyclerView.ViewHolder {
+        PieChart mainPieChart;
+        MaterialCardView mainCardView;
+        AppCompatTextView pieCardTitle;
+
+        CovidStatisticPieViewHolder(@NonNull View itemView) {
+            super(itemView);
+            mainCardView = itemView.findViewById(R.id.main_card_view);
+            mainPieChart = itemView.findViewById(R.id.pie_chart);
+            pieCardTitle = itemView.findViewById(R.id.pie_title);
+        }
     }
 
     private static class CovidStatisticTableViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/ethiopia/covid/android/util/Utils.java
+++ b/app/src/main/java/ethiopia/covid/android/util/Utils.java
@@ -3,6 +3,7 @@ package ethiopia.covid.android.util;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.net.Uri;
 import android.preference.PreferenceManager;
 import android.text.format.DateUtils;
@@ -11,8 +12,12 @@ import android.view.View;
 import android.widget.LinearLayout;
 
 import androidx.annotation.Px;
+import androidx.core.graphics.ColorUtils;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Random;
 
 public class Utils {
 
@@ -83,6 +88,33 @@ public class Utils {
         } catch (android.content.ActivityNotFoundException anfe) {
             activity.startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://play.google.com/store/apps/details?id=" + appPackageName)));
         }
+    }
+
+    public static String formatNumber(long number) {
+        String stringify = String.valueOf(number);
+        int numberOfCommas = ((int) Math.floor((stringify.length() - 1) / 3f));
+
+        StringBuilder returnable = new StringBuilder();
+        returnable.append(stringify);
+
+        for (int i = 1; i <= numberOfCommas; i++) {
+            returnable.insert( stringify.length() - ( i * 3 ), ',');
+        }
+
+        return returnable.toString();
+    }
+
+    public static List<Integer> generateColors(int number) {
+        List<Integer> returnable = new ArrayList<>();
+        float[] hsl = { 0 , 0.7f , 0.5f };
+
+        for (int i = 0; i < number; i++) {
+            hsl[0] = new Random().nextFloat() * 360f;
+            if (hsl[1] < 0.2) hsl[1] -= 0.1f; else hsl[1] = 0.7f;
+            returnable.add(ColorUtils.HSLToColor(hsl));
+        }
+
+        return returnable;
     }
 
     public static int getCurrentTheme(Context context) {

--- a/app/src/main/res/layout/stat_table_graph_element.xml
+++ b/app/src/main/res/layout/stat_table_graph_element.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    android:id="@+id/main_card_view"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:cardBackgroundColor="?appCardColor"
+    app:cardElevation="6dp"
+    app:cardCornerRadius="6dp"
+    android:layout_margin="8dp"
+    app:contentPadding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="280dp">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/line_title"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:textStyle="bold"
+        android:background="@color/grey_1x"
+        android:textColor="?appTextColorPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.github.mikephil.charting.charts.LineChart
+        android:id="@+id/line_chart"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/layout/stat_table_pie_element.xml
+++ b/app/src/main/res/layout/stat_table_pie_element.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    android:id="@+id/main_card_view"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:cardBackgroundColor="?appCardColor"
+    app:cardElevation="6dp"
+    app:cardCornerRadius="6dp"
+    android:layout_margin="8dp"
+    app:contentPadding="16dp"
+    android:layout_width="match_parent"
+    android:layout_height="280dp">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/pie_title"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:textStyle="bold"
+        android:background="@color/grey_1x"
+        android:textColor="?appTextColorPrimary"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <com.github.mikephil.charting.charts.PieChart
+        android:id="@+id/pie_chart"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,7 +9,7 @@
     <color name="white_0x">#bbffffff</color>
     <color name="white_0y">#f9ffffff</color>
     <color name="grey_0">#666666</color>
-    <color name="red_0">#fd5152</color>
+    <color name="red_0">#B03838</color>
     <color name="yellow_0">#fad84d</color>
     <color name="text_grey_0">#6c757a</color>
     <color name="blue_0">#2a359a</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,5 +12,6 @@
     <string name="death">Death</string>
     <string name="recovered">Recover</string>
     <string name="tested">Tested</string>
+    <string name="regions_affected">Regions affected</string>
 
 </resources>

--- a/app/src/test/java/ethiopia/covid/android/UtilsUnitTest.java
+++ b/app/src/test/java/ethiopia/covid/android/UtilsUnitTest.java
@@ -1,0 +1,17 @@
+package ethiopia.covid.android;
+
+import org.junit.Test;
+import ethiopia.covid.android.util.Utils;
+import static org.junit.Assert.assertEquals;
+
+public class UtilsUnitTest {
+    @Test
+    public void number_correctly_formatted() {
+        long numbers[] = { 1000 , 102344, 22 , 494, 1000000000 };
+        String formatted[] = { "1,000" , "102,344" , "22" , "494" , "1,000,000,000" };
+
+        for (int i = 0; i < numbers.length; i++) {
+            assertEquals("Testing " + numbers[i], formatted[i] , Utils.formatNumber(numbers[i]));
+        }
+    }
+}


### PR DESCRIPTION
# `Context` - Extend statistics
+ App can now draw a line graph based on the historical data fetched from `John Hopkins University` https://coronavirus.jhu.edu
+ App can now draw pie chart of regions affected in Ethiopia
+ Patients' information is now fully fetched from PMO API. 
+ Numbers are correctly formatted for better visual perception 