### PR TITLE
fix: minor problem with readding view which already has a parent. fixes #15

### DIFF
--- a/app/src/main/java/ethiopia/covid/android/ui/widget/Table.java
+++ b/app/src/main/java/ethiopia/covid/android/ui/widget/Table.java
@@ -103,7 +103,7 @@ public class Table extends LinearLayout {
                               boolean enablePagination, OnClickListener onNextButtonClicked, int pageLimit,
                               int page
     ) {
-
+        clearTable();
         this.rowItems = rowItems;
         this.currentPageLimit = pageLimit;
         this.currentPage = page;
@@ -112,7 +112,6 @@ public class Table extends LinearLayout {
                 onNextButtonClicked :
                 (enablePagination ?
                         v -> {
-                            clearTable();
                             populateTable(
                                     headers, rowItems, fixedColumn, fixedColumnCount, headerTextLengthLimit,
                                     true, null, pageLimit,


### PR DESCRIPTION
# `Fix` - Table widget error
+ If  `populateData` is called twice for a table it would crash because it tries to add views with a parent.
+ Fixes #15 